### PR TITLE
Orders Not Listed Based on Start Date in Driver App fix added

### DIFF
--- a/packages/core-api/src/Traits/HasApiModelBehavior.php
+++ b/packages/core-api/src/Traits/HasApiModelBehavior.php
@@ -549,6 +549,10 @@ trait HasApiModelBehavior
                 $builder->orderByDistance();
                 continue;
             }
+            if (strtolower($sort) == 'scheduled_at') {
+                $builder->orderBy('scheduled_at', 'asc');
+                continue;
+            }
 
             if (is_array($sort) || Str::contains($sort, ',')) {
                 $columns = !is_array($sort) ? explode(',', $sort) : $sort;


### PR DESCRIPTION
### What change does this PR introduce?

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

### Why was this change needed?

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing, Example: Closes #31 -->

### Other information (Screenshots)

<!-- Add notes or any other information here -->
<!-- Also add all the screenshots which support your changes -->
