### PR TITLE
Feat: Refactor vehicle display naming and show internal IDs, Update 'internal-id' label to 'Amazon Identifier'

### DIFF
--- a/console/translations/de-de.yml
+++ b/console/translations/de-de.yml
@@ -813,7 +813,7 @@ fleet-ops:
     height: Höhe
     host: Gastgeber
     id: ID
-    internal-id: Interne ID
+    internal-id: Amazon-Kennung
     item: Artikel
     key: Schlüssel
     label: Etikett
@@ -2276,8 +2276,8 @@ fleet-ops:
           order-type: Bestelltyp
           order-type-help-text: Die Auswahl des Bestelltyps gibt an, welche Bestellkonfigurationen von FleetYes verwendet werden sollen.
           order-type-placeholder: Bestelltyp auswählen
-          internal-id: Interne ID
-          internal-id-help-text: Verwenden Sie dieses Feld, um optional eine benutzerdefinierte oder interne Identifikationsnummer für die Bestellung festzulegen.
+          internal-id: Amazon-Kennung
+          internal-id-help-text: Verwenden Sie dieses Feld, um optional eine benutzerdefinierte Kennung festzulegen
           schedule: Startdatum
           estimated-end-date: Voraussichtliches Enddatum
           schedule-help-text: Das Datum und die Uhrzeit, zu der die Bestellung versendet wird. Wenn zu diesem Zeitpunkt kein Fahrer zugewiesen ist, schlägt der Versand fehl. Wenn die Bestellung ad-hoc ist, wird sie an Fahrer in der Nähe des Abholorts gesendet.

--- a/console/translations/en-gb.yml
+++ b/console/translations/en-gb.yml
@@ -436,7 +436,7 @@ fleet-ops:
     host: Host
     id: ID
     import: Import
-    internal-id: Internal ID
+    internal-id: Amazon Identifier
     item: Item
     key: Key
     label: Label
@@ -2037,7 +2037,7 @@ fleet-ops:
           infoblock-text: is not able to support this location.
           input-field-required: The {inputFieldName} is required.
           input-order-info-text: Input order route to view service quotes.
-          internal-id: Internal ID
+          internal-id: Amazon Identifier
           internal-id-help-text: Use this field to optionally set a custom identifier
             or internal identifier for the order.
           invalid-coordinates: Invalid coordinates!

--- a/console/translations/en-us.yaml
+++ b/console/translations/en-us.yaml
@@ -814,7 +814,7 @@ fleet-ops:
     height: Height
     host: Host
     id: ID
-    internal-id: Internal ID
+    internal-id: Amazon Identifier
     item: Item
     key: Key
     label: Label
@@ -2269,8 +2269,8 @@ fleet-ops:
           order-type: Order Type
           order-type-help-text: Selecting the order type will tell FleetYes what order configurations to use.
           order-type-placeholder: Select Order Type
-          internal-id: Internal ID
-          internal-id-help-text: Use this field to optionally set a custom identifier or internal identifier for the order.
+          internal-id: Amazon Identifier
+          internal-id-help-text: Use this field to optionally set a custom identifier
           schedule: Start Date
           estimated-end-date: Estimated End Date
           schedule-help-text: The date and time the order will be dispatched. If no driver is assigned at time of dispatch, the dispatch will fail. If the order is Ad-Hoc the order will be pinged to drivers in vicinity of pickup.

--- a/console/translations/es-ES.yml
+++ b/console/translations/es-ES.yml
@@ -836,7 +836,7 @@ fleet-ops:
     height: Altura
     host: Anfitrión
     id: Identificación
-    internal-id: Identificación interna
+    internal-id: Identificador de Amazon
     item: Elemento
     key: Llave
     label: Etiqueta
@@ -2423,9 +2423,8 @@ fleet-ops:
           order-type-help-text: Seleccionar el tipo de orden le indicará a FleetYes
             qué configuraciones de orden usar.
           order-type-placeholder: Seleccionar tipo de pedido
-          internal-id: Identificación interna
-          internal-id-help-text: Utilice este campo para definir una ID personalizada
-            o una ID interna para el pedido.
+          internal-id: Identificador de Amazon
+          internal-id-help-text: Use este campo para establecer opcionalmente un identificador personalizado
           schedule: Fecha de inicio
           estimated-end-date: Fecha estimada de finalización
           schedule-help-text: La fecha y hora en que se enviará el pedido. Si no se

--- a/console/translations/fr-fr.yml
+++ b/console/translations/fr-fr.yml
@@ -817,7 +817,7 @@ fleet-ops:
     height: Hauteur
     host: Hôte
     id: ID
-    internal-id: ID Interne
+    internal-id: Identifiant Amazon
     item: Élément
     key: Clé
     label: Étiquette
@@ -2272,8 +2272,8 @@ fleet-ops:
           order-type: Type de commande
           order-type-help-text: La sélection du type de commande indiquera à FleetYes quelles configurations de commande utiliser.
           order-type-placeholder: Sélectionner le type de commande
-          internal-id: ID interne
-          internal-id-help-text: Utilisez ce champ pour définir un identifiant personnalisé ou un identifiant interne pour la commande.
+          internal-id: Identifiant Amazon
+          internal-id-help-text: Utilisez ce champ pour définir éventuellement un identifiant personnalisé
           schedule: Date de début
           estimated-end-date: Date de fin estimée
           schedule-help-text: La date et l'heure auxquelles la commande sera expédiée. Si aucun conducteur n'est assigné au moment de l'expédition, l'expédition échouera. Si la commande est Ad-Hoc, elle sera envoyée aux conducteurs à proximité du lieu de ramassage.

--- a/console/translations/it-IT.yml
+++ b/console/translations/it-IT.yml
@@ -667,7 +667,7 @@ fleet-ops:
     height: Altezza
     host: Host
     id: ID
-    internal-id: ID Interno
+    internal-id: Identificatore Amazon
     item: Articolo
     key: Chiave
     label: Etichetta
@@ -2116,8 +2116,8 @@ fleet-ops:
           order-type: Tipo Ordine
           order-type-help-text: Selezionando il tipo di ordine, FleetYes saprà quale configurazione di ordine utilizzare.
           order-type-placeholder: Seleziona Tipo Ordine
-          internal-id: ID Interno
-          internal-id-help-text: Usa questo campo per impostare facoltativamente un identificatore personalizzato o interno per l'ordine.
+          internal-id: Identificatore Amazon
+          internal-id-help-text: Utilizzare questo campo per impostare facoltativamente un identificatore personalizzato
           schedule: Data di inizio
           estimated-end-date: Data di fine stimata
           schedule-help-text: La data e l'ora in cui l'ordine sarà spedito. Se nessun conducente è assegnato al momento della spedizione, la spedizione fallirà. Se l'ordine è Ad-Hoc, sarà inviato ai conducenti nelle vicinanze del ritiro.

--- a/console/translations/pl-pl.yml
+++ b/console/translations/pl-pl.yml
@@ -820,7 +820,7 @@ fleet-ops:
     height: Wysokość
     host: Host
     id: ID
-    internal-id: Wewnętrzny ID
+    internal-id: Identyfikator Amazon
     item: Przedmiot
     key: Klucz
     label: Etykieta
@@ -2267,8 +2267,8 @@ fleet-ops:
           order-type: Typ zamówienia
           order-type-help-text: Wybór typu zamówienia określi, jaką konfigurację zamówień wykorzysta FleetYes.
           order-type-placeholder: Wybierz typ zamówienia
-          internal-id: ID wewnętrzne
-          internal-id-help-text: Użyj tego pola, aby opcjonalnie ustawić niestandardowy identyfikator lub wewnętrzny identyfikator zamówienia.
+          internal-id: Identyfikator Amazon
+          internal-id-help-text: Użyj tego pola, aby opcjonalnie ustawić własny identyfikator
           schedule: Data rozpoczęcia
           estimated-end-date: Szacowana data zakończenia
           schedule-help-text: Data i godzina wysyłki zamówienia. Jeśli nie przypisano kierowcy, wysyłka nie powiedzie się. W przypadku zamówień Ad-Hoc powiadomienie zostanie wysłane do kierowców w pobliżu miejsca odbioru.

--- a/console/translations/vi-vn.yaml
+++ b/console/translations/vi-vn.yaml
@@ -820,7 +820,7 @@ fleet-ops:
     height: Chiều cao
     host: Máy chủ
     id: ID
-    internal-id: Mã nội bộ
+    internal-id: Mã định danh Amazon
     item: Mục
     key: Khóa
     label: Nhãn
@@ -1036,8 +1036,8 @@ fleet-ops:
           order-type: Loại đơn hàng
           order-type-help-text: Chọn loại đơn hàng sẽ cho FleetYes biết cấu hình đơn hàng cần sử dụng.
           order-type-placeholder: Chọn loại đơn hàng
-          internal-id: Mã nội bộ
-          internal-id-help-text: Sử dụng trường này để tùy chọn đặt mã định danh tùy chỉnh hoặc mã định danh nội bộ cho đơn hàng.
+          internal-id: Mã định danh Amazon
+          internal-id-help-text: Sử dụng trường này để tùy chọn đặt mã định danh tùy chỉnh
           schedule: Ngày bắt đầu
           estimated-end-date: Ngày kết thúc dự kiến
           schedule-help-text: Ngày và giờ mà đơn hàng sẽ được giao. Nếu không có tài xế được chỉ định vào thời gian giao hàng, việc giao hàng sẽ thất bại. Nếu đơn hàng là Ad-Hoc, đơn hàng sẽ được gửi đến các tài xế trong khu vực đón hàng.

--- a/packages/fleetops-data/addon/models/driver.js
+++ b/packages/fleetops-data/addon/models/driver.js
@@ -170,6 +170,15 @@ export default class DriverModel extends Model {
 
     @not('hasValidCoordinates') hasInvalidCoordinates;
 
+    @computed('vehicle.plate_number', 'vehicle.model')
+    get vehicleDisplayName() {
+        const vehicle = this.vehicle;
+        if (!vehicle) return 'No Vehicle';
+        
+        const segments = [vehicle.get('plate_number'), vehicle.get('model')];
+        return segments.filter(Boolean).join(' ').trim() || 'No Vehicle';
+    } 
+
     @computed('jobs.@each.status') get activeJobs() {
         return this.jobs.filter((order) => !['completed', 'canceled'].includes(order.status));
     }

--- a/packages/fleetops-data/addon/models/order.js
+++ b/packages/fleetops-data/addon/models/order.js
@@ -111,6 +111,15 @@ export default class OrderModel extends Model {
     @bool('dispatched') isDispatched;
     @not('dispatched') isNotDispatched;
 
+    @computed('vehicle_assigned.plate_number', 'vehicle_assigned.model')
+    get vehicleDisplayName() {
+        const vehicle = this.vehicle_assigned;
+        if (!vehicle) return 'No Vehicle';
+        
+        const segments = [vehicle.plate_number, vehicle.model];
+        return segments.filter(Boolean).join(' ').trim() || 'No Vehicle';
+    }
+
     @computed('payload.{pickup.name,current_waypoint_uui,waypoints.@each.name}')
     get pickupName() {
         const { payload, meta } = this;

--- a/packages/fleetops-data/addon/models/vehicle.js
+++ b/packages/fleetops-data/addon/models/vehicle.js
@@ -61,6 +61,11 @@ export default class VehicleModel extends Model {
         return nameSegments.filter(Boolean).join(' ').trim();
     }
 
+    @computed('plate_number', 'model') get plateNumberModel() {
+        const segments = [this.plate_number, this.model];
+        return segments.filter(segment => segment != null && segment !== '').join(' ').trim();
+    }
+
     @computed('updated_at') get updatedAgo() {
         if (!isValidDate(this.updated_at)) {
             return null;

--- a/packages/fleetops-engine/addon/components/cell/driver-name.hbs
+++ b/packages/fleetops-engine/addon/components/cell/driver-name.hbs
@@ -6,12 +6,12 @@
             {{#if @row.vehicle_assigned}}
                 <div class="ml-2 bg-gray-300 dark:bg-gray-800 opacity-50 px-1 text-xs">
                     <FaIcon @icon="car" @size="xs" class="mr-0.5" />
-                    <span>{{n-a @row.vehicle_assigned.display_name}}</span>
+                    <span>{{n-a @row.vehicle_assigned.plateNumberModel}}</span>
                 </div>
             {{else if this.driver.vehicle}}
                 <div class="ml-2 bg-gray-300 dark:bg-gray-800 opacity-50 px-1 text-xs">
                     <FaIcon @icon="car" @size="xs" class="mr-0.5" />
-                    <span>{{n-a this.driver.vehicle_name}}</span>
+                    <span>{{n-a this.driver.vehicle_assigned.plateNumberModel}}</span>
                 </div>
             {{/if}}
         </a>

--- a/packages/fleetops-engine/addon/components/cell/driver-name.hbs
+++ b/packages/fleetops-engine/addon/components/cell/driver-name.hbs
@@ -6,7 +6,7 @@
             {{#if @row.vehicle_assigned}}
                 <div class="ml-2 bg-gray-300 dark:bg-gray-800 opacity-50 px-1 text-xs">
                     <FaIcon @icon="car" @size="xs" class="mr-0.5" />
-                    <span>{{n-a @row.vehicle_assigned.plateNumberModel}}</span>
+                    <span>{{n-a @row.vehicle.plateNumberModel}}</span>
                 </div>
             {{else if this.driver.vehicle}}
                 <div class="ml-2 bg-gray-300 dark:bg-gray-800 opacity-50 px-1 text-xs">

--- a/packages/fleetops-engine/addon/components/driver-form-panel.hbs
+++ b/packages/fleetops-engine/addon/components/driver-form-panel.hbs
@@ -82,7 +82,7 @@
                         <div class="-mt-1">
                             {{#if this.driver.vehicle}}
                                 <div class="flex flex-row items-center">
-                                    <span class="text-sm dark:text-gray-500 text-gray-700 mr-3">{{this.driver.vehicle.displayName}}</span>
+                                    <span class="text-sm dark:text-gray-500 text-gray-700 mr-3">{{this.driver.vehicle.plateNumberModel}}</span>
                                 </div>
                             {{else}}
                                 <div class="flex flex-row items-center">
@@ -154,9 +154,9 @@
 
             <ContentPanel @wrapperClass="driver-details-panel" @title={{t "fleet-ops.component.driver-form-panel.driver-details"}} @open={{true}} @pad={{true}} @panelBodyClass="bg-white dark:bg-gray-800">
                 <div class="grid grid-cols-1 lg:grid-cols-2 gap-4 text-xs dark:text-gray-100">
-                    {{!-- <InputGroup @name={{t "fleet-ops.common.internal-id"}}>
+                    <InputGroup @name={{t "fleet-ops.common.internal-id"}}>
                         <Input @value={{this.driver.internal_id}} @type="text" class="w-full form-input" placeholder={{t "fleet-ops.common.internal-id"}} disabled={{cannot this.savePermission}} />
-                    </InputGroup> --}}
+                    </InputGroup>
 
                     <InputGroup @name={{t "fleet-ops.common.driver-license"}} @required={{true}}>
                         <Input @value={{this.driver.drivers_license_number}} @type="text" class="w-full form-input" placeholder={{t "fleet-ops.common.driver-license"}} disabled={{cannot this.savePermission}} />
@@ -190,7 +190,7 @@
                             @permission="fleet-ops assign-vehicle-for driver"
                             as |model|
                         >
-                            {{model.display_name}}
+                            {{model.plateNumberModel}}
                         </ModelSelect>
                     </InputGroup>
 

--- a/packages/fleetops-engine/addon/components/driver-panel.hbs
+++ b/packages/fleetops-engine/addon/components/driver-panel.hbs
@@ -46,7 +46,7 @@
                                         href="javascript:;"
                                         class="text-sm dark:text-blue-400 text-blue-600 hover:opacity-50"
                                         {{on "click" this.onClickDriverVehicle}}
-                                    >{{this.driver.vehicle.displayName}}</a>
+                                    >{{this.driver.vehicle.plateNumberModel}}</a>
                                 </div>
                             {{else}}
                                 <div class="flex flex-row items-center">

--- a/packages/fleetops-engine/addon/components/driver-panel/details.hbs
+++ b/packages/fleetops-engine/addon/components/driver-panel/details.hbs
@@ -24,10 +24,10 @@
                     <div class="field-name">{{t "fleet-ops.common.id"}}</div>
                     <ClickToCopy @value={{@driver.public_id}} class="field-value">{{n-a @driver.public_id}}</ClickToCopy>
                 </div>
-                {{!-- <div class="field-info-container space-y-2">
+                <div class="field-info-container space-y-2">
                     <div class="field-name">{{t "fleet-ops.common.internal-id"}}</div>
                     <div class="field-value">{{n-a @driver.internal_id}}</div>
-                </div> --}}
+                </div>
                 <div class="field-info-container space-y-2">
                     <div class="field-name">{{t "fleet-ops.common.driver-license"}}</div>
                     <div class="field-value">{{n-a @driver.drivers_license_number}}</div>

--- a/packages/fleetops-engine/addon/components/modals/order-form.hbs
+++ b/packages/fleetops-engine/addon/components/modals/order-form.hbs
@@ -154,7 +154,7 @@
                             <Image @src={{model.avatar_url}} @fallbackSrc={{config "defaultValues.vehicleAvatar"}} class="w-4 h-4 shadow-sm rounded-md" />
                         </div>
                         <div class="flex-1 flex flex-row truncate">
-                            <span class="uppercase">{{model.display_name}}</span>
+                            <span class="uppercase">{{model.plateNumberModel}}</span>
                         </div>
                     </div>
                 </ModelSelect>

--- a/packages/fleetops-engine/addon/components/order/schedule-card.hbs
+++ b/packages/fleetops-engine/addon/components/order/schedule-card.hbs
@@ -112,7 +112,7 @@
             {{#if @isPopup}}
                 <span class="vehicle-text-display {{unless @order.vehicle_assigned 'dark:text-gray-600 text-gray-400'}}">
                     {{#if @order.vehicle_assigned}}
-                        {{@order.vehicle_assigned.display_name}}
+                        {{@order.vehicle_assigned.plateNumberModel}}
                     {{else}}
                         {{t "fleet-ops.component.order.schedule-card.no-vehicle" default="Not Assigned"}}
                     {{/if}}
@@ -134,7 +134,7 @@
                     >
                         <div class="flex items-center">
                             <div class="flex-1 flex flex-row truncate">
-                                <span class="uppercase">{{model.display_name}}</span>
+                                <span class="uppercase">{{model.plateNumberModel}}</span>
                             </div>
                         </div>
                     </ModelSelect>

--- a/packages/fleetops-engine/addon/components/order/schedule-card.js
+++ b/packages/fleetops-engine/addon/components/order/schedule-card.js
@@ -870,15 +870,6 @@ export default class OrderScheduleCardComponent extends Component {
                         order_id: order.id,
                         order_uuid: order.uuid,
                         order_public_id: order.public_id,
-                        driver_id: driver.id,
-                        driver_uuid: driver.uuid,
-                        driver_name: driver.name,
-                        driver_email: driver.email,
-                        driver_phone: driver.phone,
-                        vehicle_id: driver.vehicle?.id,
-                        vehicle_uuid: driver.vehicle?.uuid,
-                        vehicle_name: driver.vehicle?.name,
-                        vehicle_plate: driver.vehicle?.plate,
                         type: 'success'
                     });
                 }

--- a/packages/fleetops-engine/addon/components/order/schedule-card.js
+++ b/packages/fleetops-engine/addon/components/order/schedule-card.js
@@ -50,6 +50,8 @@ export default class OrderScheduleCardComponent extends Component {
             driver_assigned: order.driver_assigned ? order.driver_assigned : null,
             driver_assigned_uuid: order.driver_assigned_uuid,
             vehicle_assigned: order.vehicle_assigned ? order.vehicle_assigned : null,
+            scheduled_at: order.scheduled_at ? order.scheduled_at : null,
+            estimated_end_date: order.estimated_end_date ? order.estimated_end_date : null,
         };
 
         let ownerInstance = getOwner(this);
@@ -324,202 +326,6 @@ export default class OrderScheduleCardComponent extends Component {
     }
 
 
-    /*
-    * Assign Driver to the order
-    */
-
-    // @action assignDriverNew(driver) {
-    //     const eventBus = this.effectiveEventBus;
-    //     try {
-    //         // Close any open modals first using Ember's modal service
-    //         if (this.modalsManager && typeof this.modalsManager.done === 'function') {
-    //             this.modalsManager.done();
-    //         }
-    //     } catch (e) {
-    //         console.error('Error closing modals:', e);
-    //     }
-
-    //     if (this.isModalOpen) {
-    //         // Prevent opening a new modal if one is already open
-    //         return;
-    //     }
-
-    //     const order = this.args.order;
-    //     this.modalsManager.done().then(() => {
-    //         this.isModalOpen = true; // Mark that a modal is being shown 
-    //         this.isAssigningDriver = true;
-    //         // If driver is not selected, confirm to unassign the driver
-
-    //         if (isBlank(driver)) {
-    //             return this.modalsManager.confirm({
-    //                 title: this.intl.t('fleet-ops.component.order.schedule-card.unassign-driver'),
-    //                 body: this.intl.t('fleet-ops.component.order.schedule-card.unassign-text', { orderId: order.public_id }),
-    //                 acceptButtonText: this.intl.t('fleet-ops.component.order.schedule-card.unassign-button'),
-    //                 confirm: async (modal) => {
-    //                     order.setProperties({
-    //                         driver_assigned: null,
-    //                         is_driver_assigned: false,
-    //                         driver_assigned_uuid: null,
-    //                         vehicle_assigned: null,
-    //                         vehicle_assigned_uuid: null
-    //                     });
-
-    //                     modal.startLoading();
-
-    //                     try {
-    //                         await order.save();
-
-    //                         // Get the current page from the router
-    //                         const currentRoute = this.router.currentRoute;
-    //                         const queryParams = currentRoute.queryParams || {};
-    //                         const currentPage = queryParams.page || 1;
-
-    //                         // Update the ref timestamp while keeping the same page
-    //                         const newQueryParams = {
-    //                             ref: Date.now(),
-    //                             page: currentPage
-    //                         };
-
-    //                         return this.router.transitionTo('console.fleet-ops.operations.scheduler.index', {
-    //                             queryParams: newQueryParams
-    //                         }).then(() => {
-    //                             if (eventBus) {
-    //                                 eventBus.publish('calendar-refresh-needed', {
-    //                                     orderId: order.id,
-    //                                     currentPage: currentPage,
-    //                                     refreshAll: true
-    //                                 });
-    //                             }
-    //                             this.notifications.success(
-    //                                 this.intl.t('fleet-ops.operations.scheduler.index.success-message', {
-    //                                     orderId: order.public_id,
-    //                                     orderAt: order.scheduledAt
-    //                                 })
-    //                             );
-    //                             modal.done();
-    //                             this.isModalOpen = false;
-    //                         });
-    //                     } catch (error) {
-    //                         this.notifications.serverError(error);
-    //                         modal.stopLoading();
-    //                     } finally {
-    //                         this.isModalOpen = false;
-    //                     }
-    //                 },
-    //                 decline: (modal) => {
-    //                     this.isAssigningDriver = false;
-    //                     modal.done();
-    //                     this.isModalOpen = false;
-    //                 },
-    //             });
-    //         }
-
-    //         else if ((driver.is_available && !driver.have_no_vehicle || (!driver.is_available && !driver.have_no_vehicle))) {
-    //             // For drivers that are available or busy but have a vehicle
-    //             return this.modalsManager.confirm({
-    //                 title: this.intl.t('fleet-ops.component.order.schedule-card.assign-driver'),
-    //                 body: driver.is_available
-    //                     ? this.intl.t('fleet-ops.component.order.schedule-card.assign-text', {
-    //                         driverName: driver.name,
-    //                         orderId: order.public_id,
-    //                     })
-    //                     : this.intl.t('fleet-ops.component.order.schedule-card.assign-busy-text', {
-    //                         driverName: driver.name,
-    //                         orderId: order.public_id,
-    //                         availability: driver.availability_message || 'Unavailable',
-    //                         button: driver.button_message || 'Continue with assignment',
-    //                     }),
-    //                 acceptButtonText: driver.is_available
-    //                     ? this.intl.t('fleet-ops.component.order.schedule-card.assign-button')
-    //                     : this.intl.t('fleet-ops.component.order.schedule-card.assign-busy-button', {
-    //                         button: driver.button_message || 'Continue with assignment',
-    //                     }),
-
-    //                 confirm: (modal) => {
-    //                     // Get the current query params
-    //                     const currentRoute = this.router.currentRoute;
-    //                     const queryParams = currentRoute.queryParams || {};
-    //                     const currentPage = queryParams.page || 1;
-    //                     modal.startLoading();
-
-    //                     // Always assign both driver and their vehicle (if available)
-    //                     const properties = {
-    //                         driver_assigned: driver,
-    //                         is_driver_assigned: true,
-    //                         driver_assigned_uuid: driver.id
-    //                     };
-
-    //                     // Add vehicle information if available
-    //                     if (driver.vehicle.id) {
-    //                         properties.vehicle_assigned = driver.vehicle;
-    //                         properties.vehicle_assigned_uuid = driver.vehicle.id;
-    //                     } else {
-    //                         properties.vehicle_assigned = null;
-    //                         properties.vehicle_assigned_uuid = null;
-    //                     }
-
-    //                     order.setProperties(properties);
-
-    //                     return order.save()
-    //                         .then(() => {
-    //                             this.isAssigningDriver = false;
-
-    //                             // Update with current page
-    //                             const newQueryParams = {
-    //                                 ref: Date.now(),
-    //                                 page: currentPage
-    //                             };
-
-    //                             return this.router.transitionTo('console.fleet-ops.operations.scheduler.index', {
-    //                                 queryParams: newQueryParams
-    //                             });
-    //                         })
-    //                         .catch((error) => {
-    //                             this.notifications.serverError(error);
-    //                         })
-    //                         .finally(() => {
-    //                             if (eventBus) {
-    //                                 // Pass the current page to the refresh handler
-    //                                 eventBus.publish('calendar-refresh-needed', {
-    //                                     orderId: order.id,
-    //                                     currentPage: currentPage,
-    //                                     refreshAll: true
-    //                                 });
-    //                             }
-    //                             this.notifications.success(
-    //                                 this.intl.t('fleet-ops.operations.scheduler.index.success-message', {
-    //                                     orderId: order.public_id,
-    //                                     orderAt: order.scheduledAt
-    //                                 })
-    //                             );
-    //                             modal.done();
-    //                             this.isModalOpen = false;
-    //                         });
-    //                 },
-    //                 decline: (modal) => {
-    //                     modal.done();
-    //                     this.isModalOpen = false;
-    //                 },
-    //             });
-    //         }
-    //         else {
-    //             const orderId = order.public_id;
-    //             // Pre-select the driver for the order
-    //             order.setProperties({
-    //                 driver_assigned: driver,
-    //                 has_driver_assigned: false,
-    //                 driver_assigned_uuid: driver.id
-    //             });
-
-    //             // Schedule reopening of edit modal instead of DOM manipulation
-    //             this.scheduleEditModalReopen(order);
-    //             // Handle modal reopening after operation
-    //             this.handleModalReopeningAfterOperation();
-    //         }
-    //     });
-    // }
-
-
     hasOrderChanged(order) {
         const snapshot = this.originalOrderSnapshot;
         if (!snapshot) return false;
@@ -573,6 +379,39 @@ export default class OrderScheduleCardComponent extends Component {
         // Check if driver is being unassigned
         const wasDriverAssigned = this.originalOrder.driver_assigned_uuid !== null && this.originalOrder.driver_assigned_uuid !== undefined;
         const isUnassigningDriver = wasDriverAssigned && !hasDriver;
+
+        // Check if there are any changes to the order, like driver, vehicle, date, etc.
+        const hasChanges = (() => {
+            // Helper function to safely compare values
+            const safeCompare = (val1, val2) => {
+                if (val1 === val2) return false;
+                if (val1 == null && val2 == null) return false; // Both null/undefined
+                if (val1 == null || val2 == null) return true;  // One is null/undefined
+                return val1 !== val2;
+            };
+
+            return (
+                safeCompare(this.originalOrder.driver_assigned_uuid, order.driver_assigned_uuid) ||
+                safeCompare(this.originalOrder.vehicle_assigned_uuid, order.vehicle_assigned_uuid) ||
+                safeCompare(this.originalOrder.scheduled_at, order.scheduled_at) ||
+                safeCompare(this.originalOrder.estimated_end_date, order.estimated_end_date)
+            );
+        })();
+
+
+        // If no changes then close the modal and show a notification
+        if (!hasChanges) {
+            this.notifications.info(this.intl.t('fleet-ops.component.order.schedule-card.no-changes', {
+                defaultValue: 'No changes were made to the order.',
+                orderId: order.public_id
+            }));
+
+            // Close the modal
+            if (this.modalsManager && typeof this.modalsManager.done === 'function') {
+                this.modalsManager.done();
+            }
+            return;
+        }
 
         if (!order.scheduled_at) {
             this.notifications.error(
@@ -672,23 +511,6 @@ export default class OrderScheduleCardComponent extends Component {
             this.handleModalReopeningAfterOperation();
             return;
         }
-
-        const hasChanges = (() => {
-            // Helper function to safely compare values
-            const safeCompare = (val1, val2) => {
-                if (val1 === val2) return false;
-                if (val1 == null && val2 == null) return false; // Both null/undefined
-                if (val1 == null || val2 == null) return true;  // One is null/undefined
-                return val1 !== val2;
-            };
-
-            return (
-                safeCompare(this.originalOrder.driver_assigned_uuid, order.driver_assigned_uuid) ||
-                safeCompare(this.originalOrder.vehicle_assigned_uuid, order.vehicle_assigned_uuid) ||
-                safeCompare(this.originalOrder.scheduled_at, order.scheduled_at) ||
-                safeCompare(this.originalOrder.estimated_end_date, order.estimated_end_date)
-            );
-        })();
 
         // Driver assigned but not available - show validation popup
         if (hasChanges && hasDriver && (!order.driver_assigned.is_available || order.vehicle_assigned.is_vehicle_available == 0)) {
@@ -932,170 +754,6 @@ export default class OrderScheduleCardComponent extends Component {
         }
     }
 
-    @action
-    assignVehicleNew(vehicle) {
-        const eventBus = this.effectiveEventBus;
-        // Track vehicle assignment attempt
-        if (this.analytics && this.analytics.isInitialized) {
-            this.analytics.trackEvent('vehicle_assignment_attempt', {
-                vehicle_id: vehicle?.id,
-                vehicle_uuid: vehicle?.uuid,
-                vehicle_name: vehicle?.display_name,
-                vehicle_plate: vehicle?.plate_number,
-                order_id: this.args.order.id,
-                order_uuid: this.args.order.uuid,
-                order_public_id: this.args.order.public_id,
-                vehicle_available: vehicle?.is_unassigned,
-                assignment_type: isBlank(vehicle) ? 'unassign' : 'assign'
-            });
-        }
-
-        try {
-            // Close any open modals using Ember's modal service
-            if (this.modalsManager && typeof this.modalsManager.done === 'function') {
-                this.modalsManager.done();
-            }
-        } catch (e) {
-            console.error('Error closing modals:', e);
-        }
-
-        if (this.isModalOpen) {
-            return;
-        }
-
-        const order = this.args.order;
-        this.modalsManager.done().then(() => {
-            this.isModalOpen = true;
-            this.isAssigningVehicle = true;
-
-            if (isBlank(vehicle)) {
-                // Unassign vehicle
-                return this.modalsManager.confirm({
-                    title: this.intl.t('fleet-ops.component.order.schedule-card.unassign-vehicle', { default: 'Unassign Vehicle' }),
-                    body: this.intl.t('fleet-ops.component.order.schedule-card.unassign-vehicle-text', { orderId: order.public_id }),
-                    acceptButtonText: this.intl.t('fleet-ops.component.order.schedule-card.unassign-button', { default: 'Unassign' }),
-                    confirm: async (modal) => {
-                        order.setProperties({
-                            vehicle_assigned: null,
-                            vehicle_assigned_uuid: null
-                        });
-
-                        modal.startLoading();
-                        try {
-                            await order.save();
-
-                            const currentRoute = this.router.currentRoute;
-                            const queryParams = currentRoute.queryParams || {};
-                            const currentPage = queryParams.page || 1;
-
-                            const newQueryParams = {
-                                ref: Date.now(),
-                                page: currentPage
-                            };
-
-                            return this.router.transitionTo('console.fleet-ops.operations.scheduler.index', {
-                                queryParams: newQueryParams
-                            }).then(() => {
-                                if (eventBus) {
-                                    eventBus.publish('calendar-refresh-needed', {
-                                        orderId: order.id,
-                                        currentPage: currentPage,
-                                        refreshAll: true
-                                    });
-                                }
-                                this.notifications.success(
-                                    this.intl.t('fleet-ops.operations.scheduler.index.success-message', {
-                                        orderId: order.public_id,
-                                        orderAt: order.scheduledAt
-                                    })
-                                );
-                                modal.done();
-                                this.isModalOpen = false;
-                            });
-                        } catch (error) {
-                            this.notifications.serverError(error);
-                            modal.stopLoading();
-                        } finally {
-                            this.isModalOpen = false;
-                        }
-                    },
-                    decline: (modal) => {
-                        this.isAssigningVehicle = false;
-                        modal.done();
-                        this.isModalOpen = false;
-                    },
-                });
-            } else {
-                // Assign vehicle with confirmation if already assigned
-                return this.modalsManager.confirm({
-                    title: this.intl.t('fleet-ops.component.order.schedule-card.assign-vehicle', { default: 'Assign Vehicle' }),
-                    body: vehicle.is_unassigned
-                        ? this.intl.t('fleet-ops.component.order.schedule-card.assign-vehicle-text', {
-                            vehicleName: vehicle.display_name,
-                            orderId: order.public_id,
-                        })
-                        : this.intl.t('fleet-ops.component.order.schedule-card.assign-vehicle-busy-text', {
-                            vehicleName: vehicle.display_name,
-                            orderId: order.public_id,
-                            availability: vehicle.availability_message || 'Assigned to another order',
-                            button: vehicle.button_message || 'Continue with assignment',
-                        }),
-                    acceptButtonText: this.intl.t('fleet-ops.component.order.schedule-card.assign-button', { default: 'Assign' }),
-
-                    confirm: (modal) => {
-                        const currentRoute = this.router.currentRoute;
-                        const queryParams = currentRoute.queryParams || {};
-                        const currentPage = queryParams.page || 1;
-
-                        modal.startLoading();
-
-                        order.setProperties({
-                            vehicle_assigned: vehicle,
-                            vehicle_assigned_uuid: vehicle.id
-                        });
-
-                        return order.save()
-                            .then(() => {
-                                this.isAssigningVehicle = false;
-
-                                const newQueryParams = {
-                                    ref: Date.now(),
-                                    page: currentPage
-                                };
-
-                                return this.router.transitionTo('console.fleet-ops.operations.scheduler.index', {
-                                    queryParams: newQueryParams
-                                });
-                            })
-                            .catch((error) => {
-                                this.notifications.serverError(error);
-                            })
-                            .finally(() => {
-                                if (eventBus) {
-                                    eventBus.publish('calendar-refresh-needed', {
-                                        orderId: order.id,
-                                        currentPage: currentPage,
-                                        refreshAll: true
-                                    });
-                                }
-                                this.notifications.success(
-                                    this.intl.t('fleet-ops.operations.scheduler.index.success-message', {
-                                        orderId: order.public_id,
-                                        orderAt: order.scheduledAt
-                                    })
-                                );
-                                modal.done();
-                                this.isModalOpen = false;
-                            });
-                    },
-                    decline: (modal) => {
-                        modal.done();
-                        this.isModalOpen = false;
-                    },
-                });
-            }
-        });
-    }
 
     /**
      * Opens the edit modal for an order using proper Ember patterns

--- a/packages/fleetops-engine/addon/components/vehicle-form-panel.hbs
+++ b/packages/fleetops-engine/addon/components/vehicle-form-panel.hbs
@@ -71,10 +71,10 @@
                     <div class="flex flex-col">
                         <h1 class="text-gray-900 dark:text-white text-2xl">
                             {{#if this.vehicle.id}}
-                                {{this.vehicle.displayName}}
+                                {{this.vehicle.plate_number}} {{this.vehicle.model}}
                             {{else}}
-                                {{#if this.vehicle.displayName}}
-                                    {{this.vehicle.displayName}}
+                                {{#if this.vehicle.plate_number}}
+                                    {{this.vehicle.plate_number}} {{this.vehicle.model}}
                                 {{else}}
                                     <span>{{t "fleet-ops.component.vehicle-form-panel.new-vehicle"}}</span>
                                 {{/if}}

--- a/packages/fleetops-engine/addon/components/vehicle-panel.hbs
+++ b/packages/fleetops-engine/addon/components/vehicle-panel.hbs
@@ -26,18 +26,18 @@
                             <Image
                                 src={{this.vehicle.photo_url}}
                                 @fallbackSrc={{config "defaultValues.vehicleImage"}}
-                                alt={{this.vehicle.name}}
+                                alt={{this.vehicle.plateNumberModel}}
                                 height="48"
                                 width="48"
                                 class="h-12 w-12 rounded-lg shadow-sm"
                             />
                             <Attach::Tooltip @class="clean" @animation="scale" @placement="top">
-                                <InputInfo @text={{this.vehicle.displayName}} />
+                                <InputInfo @text={{this.vehicle.plateNumberModel}} />
                             </Attach::Tooltip>
                         </div>
                     </div>
                     <div class="flex flex-col">
-                        <h1 class="text-gray-900 dark:text-white text-2xl">{{this.vehicle.display_name}}</h1>
+                        <h1 class="text-gray-900 dark:text-white text-2xl">{{this.vehicle.plateNumberModel}}</h1>
                     </div>
                 </div>
             </div>

--- a/packages/fleetops-engine/addon/components/vehicle-panel/details.hbs
+++ b/packages/fleetops-engine/addon/components/vehicle-panel/details.hbs
@@ -3,7 +3,11 @@
         <div class="grid grid-cols-2 gap-4 text-xs dark:text-gray-100">
             <div class="field-info-container space-y-2">
                 <div class="field-name">{{t "fleet-ops.common.name"}}</div>
-                <div class="field-value">{{n-a @vehicle.display_name}}</div>
+                <div class="field-value">{{n-a @vehicle.plateNumberModel}}</div>
+            </div>
+            <div class="field-info-container space-y-2">
+                <div class="field-name">{{t "fleet-ops.common.internal-id"}}</div>
+                <div class="field-value">{{n-a @vehicle.internal_id}}</div>
             </div>
             <div class="field-info-container space-y-2">
                 <div class="field-name">{{t "fleet-ops.common.plate-number"}}</div>

--- a/packages/fleetops-engine/addon/controllers/management/drivers/index.js
+++ b/packages/fleetops-engine/addon/controllers/management/drivers/index.js
@@ -242,8 +242,8 @@ export default class ManagementDriversIndexController extends BaseController {
                         this.notifications.serverError(error);
                     });
             },
-            valuePath: 'vehicle.display_name',
-            modelNamePath: 'display_name',
+            valuePath: 'vehicleDisplayName',
+            modelNamePath: 'vehicleDisplayName',
             resizable: true,
             width: '180px',
             filterable: true,

--- a/packages/fleetops-engine/addon/controllers/management/vehicles/index.js
+++ b/packages/fleetops-engine/addon/controllers/management/vehicles/index.js
@@ -187,7 +187,7 @@ export default class ManagementVehiclesIndexController extends BaseController {
     @tracked columns = [
         {
             label: this.intl.t('fleet-ops.common.name'),
-            valuePath: 'display_name',
+            valuePath: 'plateNumberModel',
             photoPath: 'avatar_url',
             width: '200px',
             cellComponent: 'table/cell/vehicle-name',
@@ -197,7 +197,7 @@ export default class ManagementVehiclesIndexController extends BaseController {
             sortable: true,
             filterable: true,
             filterComponent: 'filter/string',
-            filterParam: 'display_name',
+            filterParam: 'plateNumberModel',
             showOnlineIndicator: true,
         },
         {
@@ -233,6 +233,15 @@ export default class ManagementVehiclesIndexController extends BaseController {
             label: this.intl.t('fleet-ops.common.id'),
             valuePath: 'public_id',
             cellComponent: 'click-to-copy',
+            width: '120px',
+            resizable: true,
+            sortable: true,
+            filterable: true,
+            filterComponent: 'filter/string',
+        },
+        {
+            label: this.intl.t('fleet-ops.common.internal-id'),
+            valuePath: 'internal_id',
             width: '120px',
             resizable: true,
             sortable: true,

--- a/packages/fleetops-engine/addon/controllers/operations/orders/index.js
+++ b/packages/fleetops-engine/addon/controllers/operations/orders/index.js
@@ -387,7 +387,7 @@ export default class OperationsOrdersIndexController extends BaseController {
         {
             label: this.intl.t('fleet-ops.operations.orders.index.vehicle-assigned'),
             cellComponent: 'cell/vehicle-name',
-            valuePath: 'vehicle_assigned.display_name',
+            valuePath: 'vehicleDisplayName',
             modelPath: 'vehicle_assigned',
             showOnlineIndicator: true,
             width: '170px',

--- a/packages/fleetops-engine/addon/templates/operations/orders/index/view.hbs
+++ b/packages/fleetops-engine/addon/templates/operations/orders/index/view.hbs
@@ -341,7 +341,7 @@
                                     width="24"
                                     height="24"
                                     class="w-8 h-8 rounded-md shadow-sm mr-3 lg:mr-2"
-                                    alt={{@model.vehicle_assigned.display_name}}
+                                    alt={{@model.vehicle_assigned.plateNumberModel}}
                                 />
                                 <FaIcon
                                     @icon="circle"
@@ -350,7 +350,7 @@
                                 />
                             </div>
                             <div class="field-value">
-                                <div>{{n-a @model.vehicle_assigned.display_name "No Vehicle"}}</div>
+                                <div>{{n-a @model.vehicle_assigned.plateNumberModel "No Vehicle"}}</div>
                             </div>
                             <Attach::Tooltip @class="clean" @animation="scale" @placement="top">
                                 <InputInfo>
@@ -369,10 +369,10 @@
 
                     </div>
                 </div>
-                {{!-- <div class="field-info-container space-y-2">
+                <div class="field-info-container space-y-2">
                     <div class="field-name">{{t "fleet-ops.common.internal-id"}}</div>
                     <ClickToCopy @value={{@model.tracking_number.internal_id}} class="field-value">{{n-a @model.tracking_number.internal_id}}</ClickToCopy>
-                </div> --}}
+                </div>
                 <div class="field-info-container space-y-2">
                     <div class="field-name">{{t "fleet-ops.operations.orders.index.view.tracking-number"}}</div>
                     <ClickToCopy @value={{@model.tracking_number.tracking_number}} class="field-value">{{n-a @model.tracking_number.tracking_number}}</ClickToCopy>

--- a/packages/fleetops-engine/addon/utils/create-full-calendar-event-from-order.js
+++ b/packages/fleetops-engine/addon/utils/create-full-calendar-event-from-order.js
@@ -4,7 +4,7 @@ export function createOrderEventTitle(order, intl) {
     const scheduledAtTime = get(order, 'scheduledAtTime');
     const driverAssignedName = get(order, 'driver_assigned.name');
     const noVehicleText = intl ? intl.t('fleet-ops.component.order.schedule-card.no-vehicle') : 'No vehicle';
-    const vehicleAssignedName = get(order, 'driver_assigned.vehicle_name') || noVehicleText;
+    const vehicleAssignedName = get(order, 'vehicle.plateNumberModel') || noVehicleText;
     //const vehicleAssignedName = get(order, 'driver_assigned.vehicle_name') || intl.t('fleet-ops.component.order.schedule-card.no-vehicle');
     const destination = get(order, 'pickupName');
 


### PR DESCRIPTION
Standardizes vehicle display naming across models and UI by introducing and using the `plateNumberModel` and `vehicleDisplayName` computed properties. Updates all references from `display_name` to the new properties in components, controllers, and templates. Also exposes internal IDs for vehicles, drivers, and orders in relevant panels and tables, and updates translations to rename 'Internal ID' to 'Amazon Identifier'.Renamed the 'internal-id' field to 'Amazon Identifier' and updated related help texts across all supported translations. Also refactored schedule-card.js to improve order change detection and modal handling, and removed deprecated driver and vehicle assignment methods.