### PR TITLE
Fix: Use displayName in vehicle success notification

### DIFF
--- a/packages/fleetops-api/addon/components/vehicle-form-panel.js
+++ b/packages/fleetops-api/addon/components/vehicle-form-panel.js
@@ -99,7 +99,7 @@ export default class VehicleFormPanelComponent extends Component {
             return;
         }
 
-        this.notifications.success(this.intl.t('fleet-ops.component.vehicle-form-panel.success-message', { vehicleName: this.vehicle.plate_number }));
+        this.notifications.success(this.intl.t('fleet-ops.component.vehicle-form-panel.success-message', { vehicleName: this.vehicle.displayName }));
         contextComponentCallback(this, 'onAfterSave', this.vehicle);
     }
 


### PR DESCRIPTION
Replaces the vehicle plate number with displayName in the success message after saving a vehicle. This provides a more descriptive identifier in notifications.