### PR TITLE
Fix: Update modelNamePath for vehicle filters

### DIFF
--- a/packages/fleetops-engine/addon/controllers/management/drivers/index.js
+++ b/packages/fleetops-engine/addon/controllers/management/drivers/index.js
@@ -243,7 +243,7 @@ export default class ManagementDriversIndexController extends BaseController {
                     });
             },
             valuePath: 'vehicle.plate_number',
-            modelNamePath: 'vehicle.plate_number',
+            modelNamePath: 'plate_number',
             resizable: true,
             width: '180px',
             filterable: true,

--- a/packages/fleetops-engine/addon/controllers/management/fuel-reports/index.js
+++ b/packages/fleetops-engine/addon/controllers/management/fuel-reports/index.js
@@ -183,7 +183,7 @@ export default class ManagementFuelReportsIndexController extends BaseController
             filterComponentPlaceholder: this.intl.t('fleet-ops.common.select-vehicle'),
             filterParam: 'vehicle',
             model: 'vehicle',
-            modelNamePath: 'vehicle.plate_number',
+            modelNamePath: 'plate_number',
         },
         {
             label: this.intl.t('fleet-ops.common.status'),

--- a/packages/fleetops-engine/addon/controllers/management/issues/index.js
+++ b/packages/fleetops-engine/addon/controllers/management/issues/index.js
@@ -263,7 +263,7 @@ export default class ManagementIssuesIndexController extends BaseController {
             filterComponentPlaceholder: this.intl.t('fleet-ops.common.select-vehicle'),
             filterParam: 'vehicle',
             model: 'vehicle',
-            modelNamePath: 'vehicle.plate_number',
+            modelNamePath: 'plate_number',
         },
         {
             label: this.intl.t('fleet-ops.common.status'),

--- a/packages/fleetops-engine/addon/controllers/management/parking/index.js
+++ b/packages/fleetops-engine/addon/controllers/management/parking/index.js
@@ -183,7 +183,7 @@ export default class ManagementParkingIndexController extends BaseController {
             filterComponentPlaceholder: this.intl.t('fleet-ops.common.select-vehicle'),
             filterParam: 'vehicle',
             model: 'vehicle',
-            modelNamePath: 'vehicle.plate_number',
+            modelNamePath: 'plate_number',
         },
         {
             label: this.intl.t('fleet-ops.common.status'),

--- a/packages/fleetops-engine/addon/controllers/management/toll-reports/index.js
+++ b/packages/fleetops-engine/addon/controllers/management/toll-reports/index.js
@@ -183,7 +183,7 @@ export default class ManagementTollReportsIndexController extends BaseController
             filterComponentPlaceholder: this.intl.t('fleet-ops.common.select-vehicle'),
             filterParam: 'vehicle',
             model: 'vehicle',
-            modelNamePath: 'vehicle.plate_number',
+            modelNamePath: 'plate_number',
         },
         {
             label: this.intl.t('fleet-ops.common.status'),


### PR DESCRIPTION
Changed 'modelNamePath' from 'vehicle.plate_number' to 'plate_number' in multiple management controllers to ensure correct property referencing for vehicle filters.