### PR TITLE
Fix: timezone handling in orders route and date-time input

### DIFF
--- a/packages/ember-ui/addon/components/date-time-input.js
+++ b/packages/ember-ui/addon/components/date-time-input.js
@@ -17,11 +17,19 @@ export default class DateTimeInputComponent extends Component {
 
     initializeFromValue() {
         if (this.args.value instanceof Date && !isNaN(this.args.value.getTime())) {
-        this.date = format(this.args.value, this.dateFormat);
-        this.time = format(this.args.value, this.timeFormat);
+            // this.date = format(this.args.value, this.dateFormat);
+            // this.time = format(this.args.value, this.timeFormat);
+            
+            // Format date normally
+            this.date = format(this.args.value, this.dateFormat);
+            
+            // Extract time from UTC string to avoid timezone conversion
+            const utcString = this.args.value.toISOString();
+            const timeMatch = utcString.match(/T(\d{2}:\d{2})/);
+            this.time = timeMatch ? timeMatch[1] : format(this.args.value, this.timeFormat);
         } else {
-        this.date = null;
-        this.time = null;
+            this.date = null;
+            this.time = null;
         }
     }
 
@@ -33,8 +41,8 @@ export default class DateTimeInputComponent extends Component {
 
         // If date is missing, it's invalid input
         if (!this.date) {
-        this.args.onUpdate?.(null, null);
-        return;
+            this.args.onUpdate?.(null, null);
+            return;
         }
 
         // Use "00:00" (12 AM) as default if time is not set
@@ -43,17 +51,17 @@ export default class DateTimeInputComponent extends Component {
         let dateTimeInstance = parse(dateTimeString, this.dateTimeFormat, new Date());
 
         if (isNaN(dateTimeInstance.getTime())) {
-        this.args.onUpdate?.(null, null);
+            this.args.onUpdate?.(null, null);
         } else {
-        this.args.onUpdate?.(dateTimeInstance, format(dateTimeInstance, this.dateTimeFormat));
+            this.args.onUpdate?.(dateTimeInstance, format(dateTimeInstance, this.dateTimeFormat));
         }
     }
 
     @action
     didReceiveArguments() {
         if (!(this.args.value instanceof Date) || isNaN(this.args.value.getTime())) {
-        this.date = null;
-        this.time = null;
+            this.date = null;
+            this.time = null;
         }
     }
 }

--- a/packages/fleetops-engine/addon/routes/operations/orders/index.js
+++ b/packages/fleetops-engine/addon/routes/operations/orders/index.js
@@ -8,7 +8,7 @@ import { scheduleOnce } from '@ember/runloop';
 export default class OperationsOrdersIndexRoute extends Route {
     @service store;
     @service filters;
-    //@tracked timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    @tracked timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
     @service loader;
     @tracked queryParams = {
         page: { refreshModel: true },
@@ -36,7 +36,7 @@ export default class OperationsOrdersIndexRoute extends Route {
         drawerTab: { refreshModel: false },
         orderPanelOpen: { refreshModel: false },
         on: { refreshModel:true },
-        //timezone: { refreshModel: true },
+        timezone: { refreshModel: true },
         created_by: { refreshModel: true },
         updated_by: { refreshModel: true },
         created_at: { refreshModel: true },
@@ -91,7 +91,7 @@ export default class OperationsOrdersIndexRoute extends Route {
 
     @action async model(params) {
         //add timezone also here
-        //params.timezone = this.timezone;
+        params.timezone = this.timezone;
         if (params.status) {
             params.status = params.status.toLowerCase().replace(/\s+/g, '_');
         }


### PR DESCRIPTION
Uncommented and enabled timezone tracking and query param refresh in the operations orders index route, ensuring timezone is passed in model params. Updated date-time-input component to extract time from UTC string to avoid unwanted timezone conversion, improving consistency in date and time handling.