### PR TITLE
Fix: Update error messages and comment out import results UI

### DIFF
--- a/packages/core-api/src/Traits/HasApiControllerBehavior.php
+++ b/packages/core-api/src/Traits/HasApiControllerBehavior.php
@@ -1297,7 +1297,7 @@ trait HasApiControllerBehavior
                 if ($vehicleUnavailable || $activeOrder) {
                     $message = $vehicleUnavailable
                         ? 'is scheduled for maintenance'
-                        : 'is already assigned to another order during this time period.';
+                        : 'is already assigned to another order during this time period';
                 
                     return [
                         'status' => false,

--- a/packages/fleetops-engine/addon/components/modals/order-import.hbs
+++ b/packages/fleetops-engine/addon/components/modals/order-import.hbs
@@ -16,7 +16,7 @@
                         <FaIcon @icon="info-circle" class="text-red-400 mr-2 mt-0.5 flex-shrink-0" />
                         <div class="text-sm text-black dark:text-white text-left">
                             {{@options.errorMessage}}
-                            {{#if @options.importResults.successCount}}
+                            {{!-- {{#if @options.importResults.successCount}}
                             <div class="text-sm text-left mt-2 text-black dark:text-white">
                                 {{@options.importResults.successLabel}}: {{@options.importResults.successCount}}
                             </div>
@@ -25,7 +25,7 @@
                             <div class="text-sm text-left mt-2 text-black dark:text-white">
                                 {{@options.importResults.errorLabel}}: {{@options.importResults.erroredCount}}
                             </div>
-                            {{/if}}
+                            {{/if}} --}}
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Removed period from vehicle assignment error message in HasApiControllerBehavior. Commented out the import results display logic in order-import.hbs, likely for UI simplification or pending further changes.