### PR TITLE
Feat: Add fleet assignment to order schedule card

### DIFF
--- a/console/translations/de-de.yml
+++ b/console/translations/de-de.yml
@@ -1579,6 +1579,8 @@ fleet-ops:
         show-less: Weniger Details anzeigen
         show-more: Mehr Details anzeigen
       schedule-card:
+        no-fleet: Nicht zugewiesen
+        fleet-assigned: Flotte
         unavailable: Nicht verfügbar
         continue-with-assignment: Mit der Zuweisung fortfahren
         fleet-required: Flotte ist erforderlich

--- a/console/translations/de-de.yml
+++ b/console/translations/de-de.yml
@@ -1581,6 +1581,7 @@ fleet-ops:
       schedule-card:
         no-fleet: Nicht zugewiesen
         fleet-assigned: Flotte
+        select-fleet: Flotte auswählen
         unavailable: Nicht verfügbar
         continue-with-assignment: Mit der Zuweisung fortfahren
         fleet-required: Flotte ist erforderlich

--- a/console/translations/en-gb.yml
+++ b/console/translations/en-gb.yml
@@ -1371,6 +1371,9 @@ fleet-ops:
         show-less: Show less details
         show-more: Show more details
       schedule-card:
+        no-fleet: Not Assigned
+        fleet-assigned: Fleet
+        select-fleet: Select Fleet
         unavailable: Unavailable
         continue-with-assignment: Continue with assignment
         fleet-required: Fleet is required

--- a/console/translations/en-us.yaml
+++ b/console/translations/en-us.yaml
@@ -1553,6 +1553,9 @@ fleet-ops:
         show-less: Show less details
         show-more: Show more details
       schedule-card:
+        no-fleet: Not Assigned
+        fleet-assigned: Fleet
+        select-fleet: Select Fleet
         unavailable: Unavailable
         continue-with-assignment: Continue with assignment
         destination: Destination

--- a/console/translations/es-ES.yml
+++ b/console/translations/es-ES.yml
@@ -1680,6 +1680,9 @@ fleet-ops:
         show-less: Mostrar menos detalles
         show-more: Mostrar más detalles
       schedule-card:
+        no-fleet: No asignado
+        fleet-assigned: Flota
+        select-fleet: Seleccionar flota
         unavailable: No disponible
         continue-with-assignment: Continuar con la asignación
         fleet-required: Flota es requerida

--- a/console/translations/fr-fr.yml
+++ b/console/translations/fr-fr.yml
@@ -1577,6 +1577,9 @@ fleet-ops:
         show-less: Montrer moins de détails
         show-more: Montrer plus de détails
       schedule-card:
+        no-fleet: Non assigné
+        fleet-assigned: Flotte
+        select-fleet: Sélectionner une flotte
         unavailable: Indisponible
         continue-with-assignment: Continuer avec l'affectation
         fleet-required: La flotte est requise

--- a/console/translations/it-IT.yml
+++ b/console/translations/it-IT.yml
@@ -1422,6 +1422,9 @@ fleet-ops:
         show-less: Mostra meno dettagli
         show-more: Mostra più dettagli
       schedule-card:
+        no-fleet: Non assegnato
+        fleet-assigned: Flotta
+        select-fleet: Seleziona Flotta
         unavailable: Non disponibile
         continue-with-assignment: Continua con l'assegnazione
         fleet-required: La flotta è richiesta

--- a/console/translations/pl-pl.yml
+++ b/console/translations/pl-pl.yml
@@ -1570,6 +1570,9 @@ fleet-ops:
         show-less: Pokaż mniej szczegółów
         show-more: Pokaż więcej szczegółów
       schedule-card:
+        no-fleet: Nie przypisano
+        fleet-assigned: Flota
+        select-fleet: Wybierz flotę
         unavailable: Niedostępny
         continue-with-assignment: Kontynuuj przypisanie
         fleet-required: Flota jest wymagana

--- a/console/translations/vi-vn.yaml
+++ b/console/translations/vi-vn.yaml
@@ -931,6 +931,9 @@ fleet-ops:
           show-less: Weniger Details anzeigen
           show-more: Mehr Details anzeigen
         schedule-card:
+          no-fleet: Không gán
+          fleet-assigned: Đội xe
+          select-fleet: Chọn đội xe
           unavailable: Không khả dụng
           continue-with-assignment: Tiếp tục với gán
           destination: Ziel

--- a/packages/ember-ui/addon/styles/layout/next.css
+++ b/packages/ember-ui/addon/styles/layout/next.css
@@ -2360,7 +2360,8 @@ body[data-theme='dark'] .ember-power-select-option[aria-current="true"] {
     display: block;
 } */
 .console-fleet-ops-operations-scheduler-index .flb--modal.fade.show.block.flb--default-modal .order-schedule-card .calendar-driver-select,
-.console-fleet-ops-operations-scheduler-index .flb--modal.fade.show.block.flb--default-modal .order-schedule-card .calendar-vehicle-select
+.console-fleet-ops-operations-scheduler-index .flb--modal.fade.show.block.flb--default-modal .order-schedule-card .calendar-vehicle-select,
+.console-fleet-ops-operations-scheduler-index .flb--modal.fade.show.block.flb--default-modal .order-schedule-card .calendar-fleet-select
 {
     width: 265px;
 }

--- a/packages/fleetops-engine/addon/components/order/schedule-card.hbs
+++ b/packages/fleetops-engine/addon/components/order/schedule-card.hbs
@@ -49,6 +49,48 @@
             <span>{{n-a @order.createdAtWithTime}}</span>
         </div>
         
+        <!-- Fleet assigned section -->
+        <div class="flex items-center justify-between {{if @order.fleet 'fleet-assigned'}}">
+            <div class="flex flex-row items-center leading-5">
+                <div class="w-4">
+                    <FaIcon @icon="users" @size="xs" />
+                </div>
+                <span class="font-semibold">{{t "fleet-ops.component.order.schedule-card.fleet-assigned"}}</span>
+            </div>
+            
+            {{#if @isPopup}}
+                <span class="fleet-text-display {{unless @order.fleet 'dark:text-gray-600 text-gray-400'}}">
+                    {{#if @order.fleet}}
+                        {{@order.fleet.name}}
+                    {{else}}
+                        {{t "fleet-ops.component.order.schedule-card.no-fleet" default="Not Assigned"}}
+                    {{/if}}
+                </span>
+            {{else}}
+                <div class="calendar-fleet-select">
+                    <ModelSelect 
+                        @modelName="fleet"
+                        @selectedModel={{@order.fleet}}
+                        @query={{hash order_uuid=@order.id timezone=this.timezone}}
+                        @placeholder={{t "fleet-ops.component.order.schedule-card.select-fleet"}}
+                        @triggerClass="form-select form-input w-full"
+                        @infiniteScroll={{false}}
+                        @renderInPlace={{true}}
+                        @disabled={{or (eq @order.status "completed") @order.isIntegratedVendorOrder}}
+                        @allowClear={{true}}
+                        @onChange={{fn this.handleFleetChange @order}}
+                        as |model|
+                    >
+                        <div class="flex items-center">
+                            <div class="flex-1 flex flex-row truncate">
+                                <span class="uppercase">{{model.name}}</span>
+                            </div>
+                        </div>
+                    </ModelSelect>
+                </div>
+            {{/if}}
+        </div>
+        
         <!-- Driver assigned section -->
         <div class="flex items-center justify-between {{if @order.driver_assigned 'driver-assigned'}}">
             <div class="flex flex-row items-center">
@@ -71,7 +113,7 @@
                     <ModelSelect 
                         @modelName="driver"
                         @selectedModel={{@order.driver_assigned}}
-                        @query={{hash order_uuid=@order.id timezone=this.timezone}}
+                        @query={{if @order.fleet_uuid (hash order_uuid=@order.id timezone=this.timezone fleet_uuid=@order.fleet_uuid) (hash order_uuid=@order.id timezone=this.timezone)}}
                         @placeholder={{t "fleet-ops.component.modals.order-form.select-driver"}}
                         @triggerClass="form-select form-input"
                         @infiniteScroll={{false}}
@@ -122,7 +164,7 @@
                     <ModelSelect
                         @modelName="vehicle"
                         @selectedModel={{@order.vehicle_assigned}}
-                        @query={{hash order_uuid=@order.id timezone=this.timezone}}
+                        @query={{if @order.fleet_uuid (hash order_uuid=@order.id timezone=this.timezone fleet_uuid=@order.fleet_uuid) (hash order_uuid=@order.id timezone=this.timezone)}}
                         @placeholder={{t "fleet-ops.component.modals.order-form.select-vehicle"}}
                         @triggerClass="form-select form-input"
                         @infiniteScroll={{false}}

--- a/packages/fleetops-engine/addon/controllers/operations/scheduler/index.js
+++ b/packages/fleetops-engine/addon/controllers/operations/scheduler/index.js
@@ -448,7 +448,7 @@ _applyInitialFilters() {
         Promise.resolve(this.initializationCompleted).then(() => {
         this.store.query('order', { 
             // status: 'created',
-            with: ['payload', 'driverAssigned.vehicle'],
+            with: ['payload', 'driverAssigned.vehicle', 'fleet'],
             page: this.page,
             sort: '-created_at'
         }).then(orders => {
@@ -459,7 +459,7 @@ _applyInitialFilters() {
         if (!this.calscheduledOrders || this.calscheduledOrders.length === 0) {
             this.store.query('order', { 
                 // status: 'created',
-                with: ['payload', 'driverAssigned.vehicle'],
+                with: ['payload', 'driverAssigned.vehicle', 'fleet'],
                 limit: 500, // Larger limit for calendar
                 sort: '-created_at'
             }).then(calscheduledOrders => {

--- a/packages/fleetops-engine/addon/routes/operations/scheduler/index.js
+++ b/packages/fleetops-engine/addon/routes/operations/scheduler/index.js
@@ -166,7 +166,7 @@ export default class OperationsSchedulerIndexRoute extends Route {
                 const page = i + j + 1;
                 batchPromises.push(
                     this.store.query('order', {
-                        with: ['driverAssigned'],
+                        with: ['driverAssigned', 'fleet'],
                         fields: this.REQUEST_CONFIG.minimalFields,
                         filter: {
                             deleted_at: null
@@ -319,7 +319,7 @@ export default class OperationsSchedulerIndexRoute extends Route {
             const [paginatedOrders, driverUnavailability] = await Promise.all([
                 this.store.query('order', {
                     // status: 'created',
-                    with: ['payload', 'driverAssigned.vehicle'],
+                    with: ['payload', 'driverAssigned.vehicle', 'fleet'],
                     limit: listLimit,
                     sort: '-created_at',
                     page: page


### PR DESCRIPTION
Introduces fleet selection and display to the order schedule card component, including translations for multiple languages and related UI updates. Updates data loading and revert logic to handle fleet relationships, and ensures driver and vehicle assignments are cleared when fleet changes. Also updates queries to include fleet data in scheduler controller and route.